### PR TITLE
fix mismatch param name

### DIFF
--- a/Api/ServiceInterface.php
+++ b/Api/ServiceInterface.php
@@ -16,7 +16,7 @@ interface ServiceInterface
      * @param  string $email
      * @param  string $shallCreate
      * @param  string $sid
-     * @param  string $maskedQuoteId
+     * @param  string $quoteId
      * @param  string $prefix
      * @return mixed  Json Object
      */


### PR DESCRIPTION
Argument 2 passed to Magento\Framework\Reflection\TypeProcessor::resolveFullyQualifiedClassName()
fix https://github.com/paywax/wallet/issues/1